### PR TITLE
remove extra offset in BaiduImageCrawler

### DIFF
--- a/icrawler/builtin/baidu.py
+++ b/icrawler/builtin/baidu.py
@@ -65,7 +65,7 @@ class BaiduImageCrawler(Crawler):
             url_template='http://image.baidu.com/search/acjson?'
                          'tn=resultjson_com&ipn=rj&word={}&pn={}&rn=30',
             keyword=keyword,
-            offset=offset + 30,
+            offset=offset,
             max_num=max_num,
             page_step=30
         )


### PR DESCRIPTION
the offset in baidu.py causes the feeder to skip the first 30 results. I guess this is not an intended effect, or am I missing something?

Thanks!