### PR TITLE
add advanced searching options to flickr crawler

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -68,6 +68,19 @@ Here are some examples.
    for more details.
 -  ``per_page`` -- Number of photos to return per page.
 
+Some advanced searching arguments, which are not updated in the `Flickr  API
+<https://www.flickr.com/services/api/flickr.photos.search.html>`__,
+are also supported. Valid arguments and values are shown as follows.
+
+-  ``color_codes`` -- A comma-delimited list of color codes, which filters the
+   results by your chosen color(s). Please see any Flickr search page for the
+   corresponding relations between the colors and the codes.
+-  ``styles`` -- A comma-delimited list of styles, including ``blackandwhite``,
+   ``depthoffield``, ``minimalism`` and ``pattern``.
+-  ``orientation`` -- A comma-delimited list of image orientation. It can be 
+   ``landscape``, ``portrait``, ``square`` and ``panorama``. The default 
+   includes all of them.
+
 Another parameter ``size_preference`` is available for Flickr crawler, it define
 the preferred order of image sizes. Valid values are shown as follows.
 

--- a/icrawler/builtin/flickr.py
+++ b/icrawler/builtin/flickr.py
@@ -31,7 +31,8 @@ class FlickrFeeder(Feeder):
                        'group_id', 'contacts', 'woe_id', 'place_id', 'has_geo',
                        'geo_context', 'lat', 'lon', 'radius', 'radius_units',
                        'is_commons', 'in_gallery', 'is_getty', 'extras',
-                       'per_page', 'page']:  # yapf: disable
+                       'per_page', 'page',
+                       'color_codes', 'styles', 'orientation']:  # yapf: disable
                 params[key] = kwargs[key]
             elif key in ['min_upload_date', 'max_upload_date',
                          'min_taken_date', 'max_taken_date']:  # yapf: disable


### PR DESCRIPTION
Add three advanced searching options to flickr crawler, i.e., color, style and orientation. It have passed the test.

Also, I have updated the documents. Testing has also been done.