### PR TITLE
Fix google crawler - fix regex before json parsing

### DIFF
--- a/icrawler/builtin/google.py
+++ b/icrawler/builtin/google.py
@@ -151,7 +151,7 @@ class GoogleParser(Parser):
                 continue
             if 'ds:1' not in txt:
                 continue
-            txt = re.sub(r"^AF_initDataCallback\({.*key: 'ds:(\d)'.+data:function\(\){return (.+)}}\);?$",
+            txt = re.sub(r"^AF_initDataCallback\({.*key: 'ds:(\d)'.+data:(.+)}\);?$",
                          "\\2", txt, 0, re.DOTALL)
 
             meta = json.loads(txt)


### PR DESCRIPTION
The regex in the google parser was not adapted anymore:
`json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)`

The fix containing the new regex passed the unit test (test_todo.py) so obtaining 5 beautiful cats!