### PR TITLE
Fix #103 via @liyufan

### DIFF
--- a/examples/iCrawlerTK.bat
+++ b/examples/iCrawlerTK.bat
@@ -1,0 +1,10 @@
+@d:
+@cd %~dp0
+
+if exist images (
+	echo images folder exists
+) ELSE (
+	python iCrawlerTK.py 1> iCrawlerTK.log 2> iCrawlerTKErrors.log
+)
+
+pause

--- a/examples/iCrawlerTK.py
+++ b/examples/iCrawlerTK.py
@@ -1,0 +1,150 @@
+# non-tk code is mostly from from iCrawler example(s)
+# https://github.com/hellock/icrawler/
+import tkinter as tk
+import logging
+import os.path as osp
+from argparse import ArgumentParser
+from icrawler.builtin import (
+    BaiduImageCrawler,
+    BingImageCrawler,
+    FlickrImageCrawler,
+    GoogleImageCrawler,
+    GreedyImageCrawler,
+    UrlListCrawler,
+)
+import re
+
+# for non-frame app
+class MainApplication:
+
+
+    def __init__(self, master, *args, **kwargs):
+        self.master = master
+        self.frame = tk.Frame(master)
+        
+        padding_size=10
+        
+        root.grid_rowconfigure(2, weight=1)
+        root.grid_columnconfigure(1, weight=1)
+
+        self.greeting = tk.Label(master, text="iCrawler Options")
+        self.greeting.grid(row=0, columnspan=2, padx=padding_size, pady=padding_size)
+
+        label_search_string = tk.Label(master, text="Search For: ")
+        label_search_string.grid(row=1, column=0, padx=padding_size, pady=padding_size)
+        
+        # TODO: use a Text box and search each line as a keyword?
+        self.search_string =tk.StringVar(root)
+        entry_search_string = tk.Entry(master, textvariable=self.search_string)
+        entry_search_string.grid(row=1, column=1, padx=padding_size, pady=padding_size)
+        label_crawlers = tk.Label(master, text="Crawlers: ")
+        label_crawlers.grid(row=2, column=0, padx=padding_size, pady=padding_size)
+        
+        crawlers_frame = tk.Frame(master)
+        crawlers_frame.grid(row=2, column=1, padx=padding_size, pady=padding_size)
+        
+        self.crawlers_google = tk.BooleanVar()
+        tk.Checkbutton(crawlers_frame, text="Google", variable=self.crawlers_google).pack(anchor=tk.W)
+        self.crawlers_bing = tk.BooleanVar()
+        tk.Checkbutton(crawlers_frame, text="Bing", variable=self.crawlers_bing).pack(anchor=tk.W)
+        self.crawlers_baidu = tk.BooleanVar()
+        tk.Checkbutton(crawlers_frame, text="Baidu", variable=self.crawlers_baidu).pack(anchor=tk.W)
+        
+
+        self.crawl_button_text=tk.StringVar(root)
+        self.crawl_button_text.set("Go")
+        crawl_button = tk.Button(master, command=self.go_clicked, textvariable=self.crawl_button_text)
+        crawl_button.grid(row=3, columnspan=2, padx=padding_size, pady=padding_size)
+
+    def go_clicked(self):
+
+        max_number=10
+        threads=10
+
+        search_string   =self.search_string.get()
+        crawlers_bing   =self.crawlers_bing.get()
+        crawlers_baidu  =self.crawlers_baidu.get()
+        crawlers_google =self.crawlers_google.get()
+
+        gText=self.crawl_button_text.get()
+        self.crawl_button_text.set("Searching...")
+        start_download(crawlers_bing, crawlers_baidu, crawlers_google, search_string, max_number, threads)
+        self.crawl_button_text.set(gText)
+
+
+def start_download(crawlers_bing, crawlers_baidu, crawlers_google, search_string, max_number, threads):
+
+    search_string = search_string.replace(" ", "_")
+    search_folder_name = re.sub('[^a-zA-Z0-9_]', '', search_string)
+
+
+    if crawlers_google:
+        print("start testing GoogleImageCrawler")
+        google_crawler = GoogleImageCrawler(
+            downloader_threads=threads, storage={"root_dir": search_folder_name + "/google"}, log_level=logging.INFO
+        )
+        # search_filters = dict(size="large", date=(None, (2019, 1, 1)))
+        search_filters = dict(size="large")
+        # search_filters = dict(size="=1600x1200")
+        google_crawler.crawl(search_string, filters=search_filters, max_num=max_number)
+
+
+    if  crawlers_bing:
+        print("start testing BingImageCrawler")
+        bing_crawler = BingImageCrawler(downloader_threads=threads, storage={"root_dir": search_folder_name + "/bing"}, log_level=logging.INFO)
+    #   search_filters = dict(type="photo", license="commercial", layout="wide", size="large", date="pastmonth")
+        search_filters = dict(size="extralarge")
+        bing_crawler.crawl(search_string, filters = search_filters, max_num=max_number)
+
+
+    if crawlers_baidu:
+        print("start testing BaiduImageCrawler")
+        search_filters = dict(size="large", color="blue")
+        baidu_crawler = BaiduImageCrawler(downloader_threads=threads, storage={"root_dir": search_folder_name + "/baidu"})
+        baidu_crawler.crawl(search_string, max_num=max_number)
+
+
+def main():
+    parser = ArgumentParser(description="Test built-in crawlers")
+
+    parser.add_argument(
+        "--crawler",
+        nargs="+",
+        default=["google", "bing", "baidu"],
+        help="which crawlers to run",
+    )
+    parser.add_argument(
+        "--search_string",
+        nargs=1,
+        default="Lucy Hale Hot & Sexy (19 Photos)",
+        help="what to find",
+    )
+    parser.add_argument(
+        "--max_number",
+        nargs=1,
+        default=1000,
+        help="max results",
+    )
+    parser.add_argument(
+        "--threads",
+        nargs=1,
+        default=9,
+        help="number of threads",
+    )
+
+    args = parser.parse_args()
+
+    print("max: {}\nsearch:{}\n".format(args.max_number, args.search_string))
+        
+    for crawler in args.crawler:
+        eval(f"test_{crawler}({args.max_number}, \"{args.search_string}\", args.threads)")
+        print("\n")
+
+
+if __name__ == "__main__":
+    root = tk.Tk()
+    # for frame-based app
+    # MainApplication(root).pack(side="top", fill="both", expand=True)
+    # for tk-based app (non-frame)
+    app = MainApplication(root)
+    root.mainloop()

--- a/examples/iCrawlerTK.py
+++ b/examples/iCrawlerTK.py
@@ -24,7 +24,7 @@ class MainApplication:
         
         padding_size=10
         
-        root.grid_rowconfigure(2, weight=1)
+        root.grid_rowconfigure(3, weight=1)
         root.grid_columnconfigure(1, weight=1)
 
         self.greeting = tk.Label(master, text="iCrawler Options")
@@ -49,12 +49,22 @@ class MainApplication:
         tk.Checkbutton(crawlers_frame, text="Bing", variable=self.crawlers_bing).pack(anchor=tk.W)
         self.crawlers_baidu = tk.BooleanVar()
         tk.Checkbutton(crawlers_frame, text="Baidu", variable=self.crawlers_baidu).pack(anchor=tk.W)
-        
+
+        label_size = tk.Label(master, text="Size: ")
+        label_size.grid(row=3, column=0, padx=padding_size, pady=padding_size)
+        # TODO: =WxH
+        # TODO: >WxH (does baidu do this?  Or fix Baidu's error message?
+        SIZE_OPTIONS = ["          ", "extralarge", "large", "medium", "small"]
+        self.size_value = tk.StringVar(master)
+        self.size_value.set(SIZE_OPTIONS[0]) # default value
+        self.size_options = tk.OptionMenu(master, self.size_value, *SIZE_OPTIONS)
+        self.size_options.grid(row=3, column=1)
+        self.size_options.config(takefocus=1)
 
         self.crawl_button_text=tk.StringVar(root)
         self.crawl_button_text.set("Go")
-        crawl_button = tk.Button(master, command=self.go_clicked, textvariable=self.crawl_button_text)
-        crawl_button.grid(row=3, columnspan=2, padx=padding_size, pady=padding_size)
+        self.crawl_button = tk.Button(master, command=self.go_clicked, textvariable=self.crawl_button_text)
+        self.crawl_button.grid(row=4, columnspan=2, padx=padding_size, pady=padding_size)
 
     def go_clicked(self):
 
@@ -68,6 +78,7 @@ class MainApplication:
 
         gText=self.crawl_button_text.get()
         self.crawl_button_text.set("Searching...")
+        self.crawl_button.update_idletasks()
         start_download(crawlers_bing, crawlers_baidu, crawlers_google, search_string, max_number, threads)
         self.crawl_button_text.set(gText)
 
@@ -143,8 +154,6 @@ def main():
 
 if __name__ == "__main__":
     root = tk.Tk()
-    # for frame-based app
-    # MainApplication(root).pack(side="top", fill="both", expand=True)
-    # for tk-based app (non-frame)
+    root.eval('tk::PlaceWindow . center') # roughly accurate
     app = MainApplication(root)
     root.mainloop()

--- a/icrawler/builtin/google.py
+++ b/icrawler/builtin/google.py
@@ -163,6 +163,16 @@ class GoogleParser(Parser):
             uris = re.findall(r"http[^\[]*?\.(?:jpg|png|bmp)", txt)
             return [{"file_url": uri} for uri in uris]
 
+    # https://github.com/hellock/icrawler/compare/master...simonmcnair:icrawler:master
+    def parseAlternate(self, response):
+        soup = BeautifulSoup(
+            response.content.decode('utf-8', 'ignore'), 'lxml')
+        images = soup.find_all(name='img')
+        uris = []
+        for img in images:
+            if img.has_attr('src'):
+                uris.append(img['src'])
+        return [{'file_url': uri} for uri in uris]
 
 class GoogleImageCrawler(Crawler):
     def __init__(

--- a/icrawler/builtin/urllist.py
+++ b/icrawler/builtin/urllist.py
@@ -10,6 +10,9 @@ class PseudoParser(Parser):
             if self.signal.get("reach_max_num"):
                 self.logger.info("downloaded image reached max num, thread %s" " exit", threading.current_thread().name)
                 break
+            if self.signal.get("exceed_storage_space"):
+                self.logger.info("downloaded image reached max storage space, thread %s" " exit", threading.current_thread().name)
+                break
             try:
                 url = self.in_queue.get(timeout=queue_timeout)
             except queue.Empty:

--- a/icrawler/crawler.py
+++ b/icrawler/crawler.py
@@ -81,11 +81,11 @@ class Crawler:
     def init_signal(self):
         """Init signal
 
-        3 signals are added: ``feeder_exited``, ``parser_exited`` and
-        ``reach_max_num``.
+        4 signals are added: ``feeder_exited``, ``parser_exited``,
+        ``reach_max_num`` and ``exceed_storage_space``.
         """
         self.signal = Signal()
-        self.signal.set(feeder_exited=False, parser_exited=False, reach_max_num=False)
+        self.signal.set(feeder_exited=False, parser_exited=False, reach_max_num=False, exceed_storage_space=False)
 
     def set_storage(self, storage):
         """Set storage backend for downloader

--- a/icrawler/crawler.py
+++ b/icrawler/crawler.py
@@ -134,6 +134,7 @@ class Crawler:
         """
         if headers is None:
             headers = {
+                'Accept-Language': 'zh-CN,zh;q=0.8,zh-TW;q=0.7,zh-HK;q=0.5,en-US;q=0.3,en;q=0.2',
                 "User-Agent": (
                     "Mozilla/5.0 (Windows NT 10.0; Win64; x64)"
                     " AppleWebKit/537.36 (KHTML, like Gecko) "

--- a/icrawler/downloader.py
+++ b/icrawler/downloader.py
@@ -113,7 +113,8 @@ class Downloader(ThreadPool):
                     return
                 self.fetched_num -= 1
 
-        while retry > 0 and not self.signal.get("reach_max_num"):
+
+        while retry > 0 and not self.signal.get("reach_max_num") and not self.signal.get("exceed_storage_space"):
             try:
                 response = self.session.get(file_url, timeout=timeout)
             except Exception as e:
@@ -135,10 +136,16 @@ class Downloader(ThreadPool):
                 with self.lock:
                     self.fetched_num += 1
                     filename = self.get_filename(task, default_ext)
-                self.logger.info("image #%s\t%s", self.fetched_num, file_url)
-                self.storage.write(filename, response.content)
-                task["success"] = True
-                task["filename"] = filename
+                self.logger.info("image #%s\t%s\t%s", self.fetched_num, filename, file_url)
+
+                try:
+                    self.storage.write(filename, response.content)
+                except OSError as o:
+                    self.signal.set(exceed_storage_space=True)
+                else:
+                    task["success"] = True
+                finally:
+                    task["filename"] = filename # may be zero bytes if OSError happened during write()
                 break
             finally:
                 retry -= 1

--- a/icrawler/parser.py
+++ b/icrawler/parser.py
@@ -61,6 +61,11 @@ class Parser(ThreadPool):
                     "downloaded image reached max num, thread %s " "is ready to exit", current_thread().name
                 )
                 break
+            if self.signal.get("exceed_storage_space"):
+                self.logger.info(
+                    "no more storage space, thread %s " "is ready to exit", current_thread().name
+                )
+                break
             # get the page url
             try:
                 url = self.in_queue.get(timeout=queue_timeout)
@@ -110,6 +115,8 @@ class Parser(ThreadPool):
                             else:
                                 break
                         if self.signal.get("reach_max_num"):
+                            break
+                        if self.signal.get("exceed_storage_space"):
                             break
                     self.in_queue.task_done()
                     break


### PR DESCRIPTION
@liyufan posted a fix for "KeyError:'data' when using BaiduImageCrawler" when the response is:

`{"antiFlag":1,"message":"Forbid spider access","bfe_log_id":"xxxxxx random numbers xxxxxx"}`

Other errors should log the JSON received but I did not include that.

`if content["data"]
	...
else
	self.logger.debug(content)`

Log default headers in pownloader.py 116 (add line 119/120):

'        while retry > 0 and not self.signal.get("reach_max_num"):
            try:
                response = self.session.get(file_url, timeout=timeout)
                #POF TEMP:
                self.logger.error(response.request.headers)'